### PR TITLE
fix: order ancestor headers

### DIFF
--- a/crates/executor/guest/src/io.rs
+++ b/crates/executor/guest/src/io.rs
@@ -57,7 +57,7 @@ impl<P: NodePrimitives> ClientExecutorInput<P> {
     /// Gets the immediate parent block's header.
     #[inline(always)]
     pub fn parent_header(&self) -> &Header {
-        self.ancestor_headers.last().unwrap()
+        &self.ancestor_headers[0]
     }
 
     /// Creates a [`WitnessDb`].
@@ -84,10 +84,8 @@ impl<P: NodePrimitives> WitnessInput for ClientExecutorInput<P> {
 
     #[inline(always)]
     fn sealed_headers(&self) -> impl Iterator<Item = SealedHeader> {
-        self.ancestor_headers
-            .iter()
-            .map(|h| SealedHeader::seal_slow(h.clone()))
-            .chain(once(SealedHeader::seal_slow(self.current_block.header.clone())))
+        once(SealedHeader::seal_slow(self.current_block.header.clone()))
+            .chain(self.ancestor_headers.iter().map(|h| SealedHeader::seal_slow(h.clone())))
     }
 }
 

--- a/crates/executor/host/src/bins/persist_report_hook.rs
+++ b/crates/executor/host/src/bins/persist_report_hook.rs
@@ -31,6 +31,7 @@ const PRECOMPILES: [&str; 10] = [
     "kzg-point-evaluation",
 ];
 
+#[allow(dead_code)]
 #[derive(Serialize, Deserialize)]
 struct ExecutionReportData {
     chain_id: u64,

--- a/crates/mpt/src/mpt.rs
+++ b/crates/mpt/src/mpt.rs
@@ -871,7 +871,7 @@ pub fn to_nibs(slice: &[u8]) -> Vec<u8> {
 /// bytes.
 pub fn to_encoded_path(mut nibs: &[u8], is_leaf: bool) -> Vec<u8> {
     let mut prefix = (is_leaf as u8) * 0x20;
-    if nibs.len() % 2 != 0 {
+    if !nibs.len().is_multiple_of(2) {
         prefix += 0x10 + nibs[0];
         nibs = &nibs[1..];
     }
@@ -931,7 +931,7 @@ pub fn mpt_from_proof(proof_nodes: &[MptNode]) -> Result<MptNode, FromProofError
                 if let Some(child) = children.iter_mut().flatten().find(
                     |child| matches!(child.as_data(), MptNodeData::Digest(d) if d == child_ref),
                 ) {
-                    *child = Box::new(replacement);
+                    **child = replacement;
                 } else {
                     return Err(FromProofError::NodeHasInvalidSuccessor(i));
                 }

--- a/crates/storage/rpc-db/src/basic.rs
+++ b/crates/storage/rpc-db/src/basic.rs
@@ -226,7 +226,7 @@ where
             let keys = used_keys
                 .iter()
                 .map(|key| B256::from(*key))
-                .chain(modified_keys.clone().into_iter())
+                .chain(modified_keys.clone())
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect::<Vec<_>>();

--- a/crates/storage/rpc-db/src/execution_witness.rs
+++ b/crates/storage/rpc-db/src/execution_witness.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::{cmp::Reverse, collections::BTreeMap, marker::PhantomData};
 
 use alloy_consensus::Header;
 use alloy_primitives::{map::HashMap, Address, B256};
@@ -141,6 +141,9 @@ where
     }
 
     async fn ancestor_headers(&self) -> Result<Vec<Header>, RpcDbError> {
-        Ok(self.ancestor_headers.values().cloned().collect())
+        // The ancestor headers must be ordered from most recent to older
+        let mut ancestor_headers: Vec<Header> = self.ancestor_headers.values().cloned().collect();
+        ancestor_headers.sort_by_key(|header| Reverse(header.number));
+        Ok(ancestor_headers)
     }
 }


### PR DESCRIPTION
When the `execution-witness` feature is not enabled, the ancestor headers must be ordered from older to most recent.